### PR TITLE
Fixed to follow current way of Guard plugin.

### DIFF
--- a/guard-tap.gemspec
+++ b/guard-tap.gemspec
@@ -24,5 +24,4 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'guard-rspec'
-  spec.add_development_dependency 'rspec'
 end

--- a/guard-tap.gemspec
+++ b/guard-tap.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_dependency 'guard', '>= 1.8'
+  spec.add_dependency 'guard-compat', '~> 1.0'
 
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'guard-rspec'

--- a/lib/guard/tap.rb
+++ b/lib/guard/tap.rb
@@ -1,9 +1,6 @@
 require "guard/tap/version"
 
-require 'guard'
-require 'guard/watcher'
 require 'guard/compat/plugin'
-
 require 'shellwords'
 
 module Guard

--- a/lib/guard/tap.rb
+++ b/lib/guard/tap.rb
@@ -1,13 +1,13 @@
 require "guard/tap/version"
 
 require 'guard'
-require 'guard/guard'
 require 'guard/watcher'
+require 'guard/compat/plugin'
 
 require 'shellwords'
 
 module Guard
-  class Tap < Guard
+  class Tap < Plugin
 
     autoload :Runner, 'guard/tap/runner'
 

--- a/lib/guard/tap/runner.rb
+++ b/lib/guard/tap/runner.rb
@@ -16,7 +16,7 @@ module Guard
 
           IO.popen(command, "r+"){ |io|
             while line = io.gets
-              UI.debug line
+              ::Guard::Compat::UI.debug line
               if line =~ /^ok/
                 now_error = false
                 flush_error.call
@@ -47,7 +47,7 @@ module Guard
         end
 
         def notify log_level, message, args = { }
-          ::Guard::UI.send log_level, message
+          ::Guard::Compat::UI.send log_level, message
           ::Guard::Notifier.notify message, args
         end
 

--- a/spec/guard/tap/runner_spec.rb
+++ b/spec/guard/tap/runner_spec.rb
@@ -29,7 +29,7 @@ describe Guard::Tap::Runner do
 
     it 'handles not ok (TODO)' do
       runner.should_not_receive(:notify_error)
-      runner.run('echo not ok 1 # TODO')
+      runner.run('echo not ok 1 \\# TODO')
     end
   end
 

--- a/spec/guard/tap/runner_spec.rb
+++ b/spec/guard/tap/runner_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'guard/compat/test/helper'
 
 describe Guard::Tap::Runner do
 
@@ -39,7 +40,7 @@ describe Guard::Tap::Runner do
     end
 
     it 'calls UI and Notifier' do
-      Guard::UI.should_receive(:info).with('hi')
+      Guard::Compat::UI.should_receive(:info).with('hi')
       Guard::Notifier.should_receive(:notify).with('hi', foo: 'bar')
       runner.notify :info, 'hi', foo: 'bar'
     end

--- a/spec/guard/tap_spec.rb
+++ b/spec/guard/tap_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'guard/compat/test/helper'
 
 describe Guard::Tap do
 
@@ -39,7 +40,7 @@ describe Guard::Tap do
     end
 
     context 'with the :command option' do
-      let(:guard) { Guard::Tap.new(nil, :command => 'perl') }
+      let(:guard) { Guard::Tap.new(:command => 'perl') }
 
       it 'makes the command with specified command' do
         guard.make_command('test.pl').should == 'perl test.pl 2>&1'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,12 +7,12 @@ RSpec.configure do |config|
     ENV["GUARD_ENV"] = 'test'
     @project_path    = Pathname.new(File.expand_path('../../', __FILE__))
 
-    Guard::UI.stub(:info)
-    Guard::UI.stub(:debug)
-    Guard::UI.stub(:error)
-    Guard::UI.stub(:success)
-    Guard::UI.stub(:warning)
-    Guard::UI.stub(:notify)
+    Guard::Compat::UI.stub(:info)
+    Guard::Compat::UI.stub(:debug)
+    Guard::Compat::UI.stub(:error)
+    Guard::Compat::UI.stub(:success)
+    Guard::Compat::UI.stub(:warning)
+    Guard::Compat::UI.stub(:notify)
   end
 
   config.after(:each) do


### PR DESCRIPTION
`guard/guard` is no longer use to create plugin at current version of guard.
It's time to use `guard/compat/plugin`.

I'm sorry for not related commits: fb381cf and d6c5b3c .
I have to fix these error to run all test.
